### PR TITLE
fix: 쿼리 네이밍 컨벤션 통일

### DIFF
--- a/app/(main)/action.ts
+++ b/app/(main)/action.ts
@@ -38,7 +38,7 @@ export const getMyProjectsWithCounts = async (): Promise<
   let projects: ProjectWithCounts[];
   try {
     const result = await api.getMyProjectsWithCounts({
-      orderBy: 'created_at',
+      orderBy: 'createdAt',
       order: 'desc',
     });
     projects = result.data;

--- a/app/(main)/projects/(projects)/[projectId]/components/ProjectTab.tsx
+++ b/app/(main)/projects/(projects)/[projectId]/components/ProjectTab.tsx
@@ -65,7 +65,7 @@ const TaskTabMenu = ({
 
   const handleSortChange = (value: string) => {
     const searchParams = new URLSearchParams(params);
-    searchParams.set("order_by", value);
+    searchParams.set("orderBy", value);
     searchParams.delete("page");
     router.push(`?${searchParams.toString()}`);
   };
@@ -107,7 +107,7 @@ const TaskTabMenu = ({
         options={[
           {
             label: "생성순",
-            value: "created_at",
+            value: "createdAt",
           },
           {
             label: "이름순",
@@ -115,10 +115,10 @@ const TaskTabMenu = ({
           },
           {
             label: "기한임박순",
-            value: "end_date",
+            value: "endDate",
           },
         ]}
-        value={params.get("order_by") || ""}
+        value={params.get("orderBy") || ""}
         onChange={handleSortChange}
       />
       <Dropdown

--- a/app/(main)/projects/(projects)/[projectId]/tasks/page.tsx
+++ b/app/(main)/projects/(projects)/[projectId]/tasks/page.tsx
@@ -27,14 +27,14 @@ const TaskListPage = async ({
   }>;
   searchParams: Promise<{
     page?: number;
-    order_by?: 'created_at' | 'end_date' | 'title';
+    orderBy?: 'createdAt' | 'endDate' | 'title';
     status?: TaskStatus;
     assignee?: number;
     keyword?: string;
   }>;
 }) => {
   const { projectId: projectIdString } = await params;
-  const { order_by, status, assignee, keyword, page } = await searchParams;
+  const { orderBy, status, assignee, keyword, page } = await searchParams;
   const projectId = Number(projectIdString);
   if (isNaN(projectId)) {
     return redirect('/projects');
@@ -42,7 +42,7 @@ const TaskListPage = async ({
   const { data } = await getTasksByProjectId(projectId, {
     page: page ?? 1,
     limit: PAGE_SIZE,
-    order_by,
+    orderBy,
     status,
     assignee,
     keyword,

--- a/app/(main)/projects/(projects)/actions.tsx
+++ b/app/(main)/projects/(projects)/actions.tsx
@@ -18,7 +18,7 @@ export const getMyProjectsWithCounts = async ({
   let projectsWithCounts: ProjectWithCounts[] = [];
   try {
     const result = await api.getMyProjectsWithCounts({
-      orderBy: sort === 'latest' ? 'created_at' : 'name',
+      orderBy: sort === 'latest' ? 'createdAt' : 'name',
       order: sort === 'latest' ? 'desc' : 'asc',
     });
     projectsWithCounts = result.data;

--- a/shared/api.ts
+++ b/shared/api.ts
@@ -120,7 +120,7 @@ export const getMyProjectsWithCounts = async ({
   orderBy,
   order,
 }: {
-  orderBy?: 'created_at' | 'name';
+  orderBy?: 'createdAt' | 'name';
   order?: 'asc' | 'desc';
 }): Promise<PaginationResponse<ProjectWithCounts>> => {
   try {
@@ -246,7 +246,7 @@ export const removeMember = async (projectId: number, userId: number) => {
 };
 
 export interface GetTasksByProjectIdParams {
-  order_by?: 'created_at' | 'end_date' | 'title';
+  orderBy?: 'createdAt' | 'endDate' | 'title';
   status?: TaskStatus;
   assignee?: number;
   from?: Date;

--- a/types/pagination.ts
+++ b/types/pagination.ts
@@ -3,7 +3,7 @@ import { TaskStatus } from "./TaskStatus";
 export interface PaginationOption {
   page: number;
   limit: number;
-  order_by?: string;
+  orderBy?: string;
   order?: "asc" | "desc";
   keyword?: string;
 }
@@ -15,7 +15,7 @@ export interface PaginationResponse<T> {
 
 export interface FindByTasksByProjectIdPaginationOption
   extends PaginationOption {
-  order_by?: "createdAt" | "endDate" | "name";
+  orderBy?: "createdAt" | "endDate" | "name";
   status?: TaskStatus;
   assignee?: number;
   fromStartDate?: Date;


### PR DESCRIPTION
## ✨ 변경 내용
- 프론트 쿼리문의 필드명의 네이밍 컨벤션을 통일했습니다

## ❔ 이유
- 백엔드와 서로 다른 이름 때문에 정렬 기능이 동작 하지 않아 수정합니다

