### PR TITLE
fix: 하위할일 데이터 추출 방식 수정

### DIFF
--- a/shared/api.ts
+++ b/shared/api.ts
@@ -346,7 +346,7 @@ export const getSubTasksByTaskId = async (
 ): Promise<SubTask[]> => {
   try {
     const response = await axios.get(`/tasks/${taskId}/subtasks`);
-    return response.data;
+    return response.data.data;
   } catch (error) {
     logError(error);
     if (error instanceof AxiosError) {


### PR DESCRIPTION
## ✨ 변경 내용
- 할 일 상세 페이지 내부의 하위 할일의 리스폰스 값 추출 형식을  data -> data.data 로 수정했습니다

## ❔ 이유
 하위 할일 리스폰스 객체 내부의 data 를 읽을 수 있게 수정했습니다